### PR TITLE
Pulling in vault credentials directly via the vault-spring java library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.vault:spring-vault-core:2.3.1'
     implementation 'org.liquibase:liquibase-core'
     implementation 'org.apache.commons:commons-lang3'
     implementation 'com.google.guava:guava:31.1-jre'

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,14 @@
+
+# postgres
+brew install postgres
+pg_ctl -D /usr/local/var/postgres start # stop to stop
+# psql postgres
+# CREATE ROLE wds WITH LOGIN PASSWORD 'wds';
+# CREATE DATABASE wds;
+# GRANT ALL PRIVILEGES ON DATABASE wds TO wds;
+
+# gradle
+sdkman install gradle
+gradle bootRun
+
+# gradle alternative if we commit ./gradlew: ./gradlew bootRun

--- a/src/main/java/org/databiosphere/workspacedataservice/AppConfig.java
+++ b/src/main/java/org/databiosphere/workspacedataservice/AppConfig.java
@@ -1,0 +1,65 @@
+package org.databiosphere.workspacedataservice;
+
+import org.databiosphere.workspacedataservice.shared.model.secrets.DummySecret;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.vault.authentication.ClientAuthentication;
+import org.springframework.vault.authentication.TokenAuthentication;
+import org.springframework.vault.client.VaultEndpoint;
+import org.springframework.vault.config.AbstractVaultConfiguration;
+import org.springframework.vault.core.VaultTemplate;
+import org.springframework.vault.support.VaultResponseSupport;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Configuration
+public class AppConfig extends AbstractVaultConfiguration {
+
+    @Value("${vault.uri}")
+    URI vaultUri;
+
+    @Value("${vault.token-path}")
+    String vaultTokenPath;
+
+    @Value("${vault.env}")
+    String vaultEnv;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppConfig.class);
+
+    @Override
+    public VaultEndpoint vaultEndpoint() {
+        return VaultEndpoint.from(vaultUri);                          
+    }
+
+    @Override
+    public ClientAuthentication clientAuthentication() {
+        String token;
+        try {
+            token = Files.readString(Path.of(vaultTokenPath));
+            LOGGER.info("Successfully retrieved vault token at path {}", vaultTokenPath);
+        } catch (IOException e) {
+            throw new RuntimeException(String.format("Vault token file not found: %s", vaultTokenPath));
+        }
+
+        return new TokenAuthentication(token);
+    }
+
+    @Bean
+    public DummySecret dummySecret(VaultTemplate vaultTemplate) {
+        LOGGER.info("Loading secret at path {}", wdsSecretsPath("dummy-secret"));
+        VaultResponseSupport<DummySecret> response =
+                vaultTemplate.read(wdsSecretsPath("dummy-secret"), DummySecret.class);
+        assert response != null; // TODO log missing secret error
+        return response.getData();
+    }
+
+    private String wdsSecretsPath(String relativePath) {
+        return String.format("secret/dsde/%s/workspace-data-service/%s", vaultEnv, relativePath);
+    }
+}

--- a/src/main/java/org/databiosphere/workspacedataservice/dao/EntityDao.java
+++ b/src/main/java/org/databiosphere/workspacedataservice/dao/EntityDao.java
@@ -9,6 +9,7 @@ import org.databiosphere.workspacedataservice.service.model.EntityReference;
 import org.databiosphere.workspacedataservice.service.model.InvalidEntityReference;
 import org.databiosphere.workspacedataservice.shared.model.Entity;
 import org.databiosphere.workspacedataservice.shared.model.EntityType;
+import org.databiosphere.workspacedataservice.shared.model.secrets.DummySecret;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -39,7 +40,8 @@ public class EntityDao {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EntityDao.class);
 
-    public EntityDao(JdbcTemplate template, NamedParameterJdbcTemplate namedParameterJdbcTemplate, ObjectMapper objectMapper) {
+    public EntityDao(JdbcTemplate template, NamedParameterJdbcTemplate namedParameterJdbcTemplate, ObjectMapper objectMapper, DummySecret dummySecret) {
+        LOGGER.info("Dummy secret: {}", dummySecret.getPassword());
         this.template = template;
         this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
         this.objectMapper = objectMapper;

--- a/src/main/java/org/databiosphere/workspacedataservice/shared/model/secrets/DummySecret.java
+++ b/src/main/java/org/databiosphere/workspacedataservice/shared/model/secrets/DummySecret.java
@@ -1,0 +1,10 @@
+package org.databiosphere.workspacedataservice.shared.model.secrets;
+
+public class DummySecret {
+
+    String password;
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,7 @@ spring.datasource.password=${WDS_DB_PASSWORD:wds}
 
 spring.liquibase.change-log=classpath:db/changelog.xml
 spring.liquibase.enabled=true
+
+vault.uri=${WDS_VAULT_URI:https://clotho.broadinstitute.org:8200}
+vault.token-path=/Users/${USER}/.vault-token
+vault.env=${WDS_VAULT_ENV:dev}


### PR DESCRIPTION
PR pulling in credential via vault-spring:
- Main vault configuration take place in `AppConfig.java`
- Additional vault properties. Mostly can be overridden easily with environment variables, except for the .vault-token path (due to annoying pathing variance which could be solved in a different way)
- Added an unnecessary call to Vault from the EntityDAO to demonstrate (see log line below)
- setup.sh walks through commands for setting up local postgres(url
![Screen Shot 2022-06-15 at 5 10 40 PM](https://user-images.githubusercontent.com/8800717/173931503-4caf9cf0-313c-4b0b-9a53-279b96769227.png)
)